### PR TITLE
Fix error message formatting in tokenizer utils

### DIFF
--- a/src/mistral_common/tokens/tokenizers/utils.py
+++ b/src/mistral_common/tokens/tokenizers/utils.py
@@ -103,8 +103,8 @@ def download_tokenizer_from_hf_hub(
 
         if len(repo_files) == 0:
             raise ConnectionError(
-                "Could not connect to the Hugging Face Hub and no local files were found for the repo ID {repo_id} "
-                "and revision {revision}. Please check your internet connection and try again."
+                f"Could not connect to the Hugging Face Hub and no local files were found for the repo ID {repo_id} "
+                f"and revision {revision}. Please check your internet connection and try again."
             ) from e
 
     valid_tokenizer_files = []


### PR DESCRIPTION
## Summary
- fix string formatting in error handling when downloading tokenizers from HF Hub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d761a8a84833398db6069b770898f